### PR TITLE
Modify regex to also support content folders with a dot as separator.

### DIFF
--- a/lib/Page.js
+++ b/lib/Page.js
@@ -16,7 +16,7 @@ function Page(site, parent, directory, index, callback) {
 	site.pageCount++;
 	this.site = site;
 	this.directory = directory;
-	this.name = parent ? directory.replace(/^[0-9]+-/g, '') : 'home';
+	this.name = parent ? directory.replace(/^\d+[\.-]/g, '') : 'home';
 	this.slug = parent ? slug(this.name) : '';
 
 	this.files = new Collection();


### PR DESCRIPTION
This is Stacey's default. Eg. also support 03.project in addition to 03-project.
