### PR TITLE
Rework TemplateParam to work with newer Jade versions. Also update Jade.

### DIFF
--- a/example/templates/default/html.jade
+++ b/example/templates/default/html.jade
@@ -1,10 +1,10 @@
-!!! 5
-html(lang='en')  
+doctype html
+html(lang='en')
   head
     meta(name="description", content=page.description)
     link(rel="stylesheet", href="/assets/styles/skeleton.css")
     link(rel="stylesheet", href="/assets/styles/styles.css")
-    title Example Website - #{page.title}  
+    title Example Website - #{page.title}
 body
   div.container
     div.three.columns

--- a/lib/Page.js
+++ b/lib/Page.js
@@ -65,7 +65,8 @@ Page.prototype = {
 
 	template: function(name, param) {
 		var templateParam = new TemplateParam(this, param);
-		return getTemplate(this, name)(templateParam);
+		var foundTemplate = getTemplate(this, name);
+		return foundTemplate(templateParam);
 	},
 
 	getUri: function(file) {
@@ -100,7 +101,7 @@ Page.prototype = {
 			.get(this.href())
 			.buffer()
 			.end(function(err, res) {
-				callback(err, res.text)
+				callback(err, res.text);
 			});
 	},
 

--- a/lib/TemplateParam.js
+++ b/lib/TemplateParam.js
@@ -1,33 +1,44 @@
 var marked = require('marked');
 
 function TemplateParam(page, param) {
-	param.page = page;
-	this.page = page;
-	this.site = page.site;
-	this.root = page.site.root;
-	this.param = param;
-}
-
-TemplateParam.prototype = {
-	isActive: function(page) {
-		return page == this.param._activePage;
-	},
-
-	inPath: function(page) {
-		return this.isActive(page) || page.isAncestor(this.param._activePage);
-	},
-
-	markdown: function(string) {
-		return string ? marked(string) : '';
-	},
-
-	template: function(name, page, param) {
-		return (page || this.page).template(name, param || this.param);
-	},
-
-	paginate: function(collection, perPage) {
-		return collection.paginate(this.param.number, perPage);
+	var savedScope;
+	/*
+	*	Jade calls the prototype functions (eg. isActive, inPath etc.)
+	*	without their context since version 0.31.0 (this == the global object).
+	*	In order to preserve the context, we create a reference to "this"
+	*	called savedScope and wrap the whole TemplateParam function in a closure,
+	*	so that this var is always accessible.
+	*/
+	function Closure() {
+		param.page = page;
+		this.page = page;
+		this.site = page.site;
+		this.root = page.site.root;
+		this.param = param;
+		savedScope = this;
 	}
-};
+	Closure.prototype = {
+		isActive: function(page) {
+			return page == savedScope.param._activePage;
+		},
+
+		inPath: function(page) {
+			return savedScope.isActive(page) || page.isAncestor(savedScope.param._activePage);
+		},
+
+		markdown: function(string) {
+			return string ? marked(string) : '';
+		},
+
+		template: function(name, page, param) {
+			return (page || savedScope.page).template(name, param || savedScope.param);
+		},
+
+		paginate: function(collection, perPage) {
+			return collection.paginate(savedScope.param.number, perPage);
+		}
+	};
+	return new Closure();
+}
 
 module.exports = TemplateParam;

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "dependencies": {
     "async": "~0.2.6",
     "express": "~3.1.0",
-    "jade": "~0.30.0",
+    "jade": "~1.3.0",
     "superagent": "~0.14.0",
     "tiny-lr": "0.0.4",
     "node-watch": "~0.3.1",


### PR DESCRIPTION
Jade included a breaking change in 0.31 . It prevented the template() function of TemplateParam from accessing it's own properties (this was equal the global object).

To fix it I wrapped the whole thing in a closure and added a var to preserve the local context. This continues to work with older Jade versions as well.

There's one more change in Jade 1.0.0 relevant to this project: !!! 5 has been deprecated for doctype html . I have updated the example accordingly.
