### PR TITLE
Add support for image/file descriptions

### DIFF
--- a/lib/File.js
+++ b/lib/File.js
@@ -32,6 +32,15 @@ function File(page, index, filename, callback) {
 			return callback();
 		});
 	};
+	var setDescription = function(callback) {
+		fs.readFile(file.uri + page.site.settings.contentExtension, 'utf8', function(err, content) {
+			if (err)
+				file.description = null;
+			else
+				file.description = content;
+			return callback();
+		});
+	};
 	var setDimensions = function(callback) {
 		if (file.type == 'image') {
 			gm(file.uri)
@@ -49,7 +58,7 @@ function File(page, index, filename, callback) {
 			callback();
 		}
 	};
-	async.parallel([setFileProperties, setDimensions], callback);
+	async.parallel([setFileProperties, setDimensions, setDescription], callback);
 }
 
 /**


### PR DESCRIPTION
Fixes issue #21. Descrriptions are read from text files having the same name as the images, but with the contentExtension added.

Eg. nicedog.jpg -> nicedog.jpg.md
