### PR TITLE
Remove readIfExists

### DIFF
--- a/lib/Parsers.js
+++ b/lib/Parsers.js
@@ -108,7 +108,7 @@ Parsers.prototype = {
 
 	parseFile: function(file, page, callback) {
 		var parsers = this;
-		fsUtil.readIfExists(file, function(err, buffer) {
+		fs.readFile(file, 'utf8', function(err, buffer) {
 			if (!err)
 				parsers.parse(buffer.toString(), page);
 			callback(err);

--- a/lib/Site.js
+++ b/lib/Site.js
@@ -18,7 +18,7 @@ var fsUtil = require('./util/fs.js'),
 require('util').inherits(Site, require('events').EventEmitter);
 
 var loadSettings = function(site, callback) {
-	fsUtil.readIfExists(site.getUri('settings.md'), function(err, data) {
+	fs.readFile(site.getUri('settings.md'), 'utf8', function(err, data) {
 		site.settings = err ? {} : parsedown(data);
 		if (!site.settings.contentExtension)
 			site.settings.contentExtension = settings.contentExtension;

--- a/lib/util/fs.js
+++ b/lib/util/fs.js
@@ -70,18 +70,6 @@ var util = {
 		}, _callback || callback);
 	},
 
-	readIfExists: function(file, callback) {
-		fs.exists(file, function(exists) {
-			if (exists) {
-				fs.readFile(file, 'utf8', function(err, buffer) {
-					callback(err, buffer);
-				});
-			} else {
-				callback(new Error('File not found: ' + file));
-			}
-		});
-	},
-
 	isFile: function(uri, callback) {
 		fs.stat(uri, function(err, stats) {
 			callback(!err && stats && stats.isFile());
@@ -143,4 +131,3 @@ var util = {
 };
 
 module.exports = util;
-


### PR DESCRIPTION
See http://nodejs.org/api/fs.html#fs_fs_exists_path_callback

Quote: "In particular, checking if a file exists before opening it is an anti-pattern that leaves you vulnerable to race conditions: another process may remove the file between the calls to fs.exists() and fs.open(). Just open the file and handle the error when it's not there."
