### PR TITLE
Don't lazy load available templates

### DIFF
--- a/lib/Page.js
+++ b/lib/Page.js
@@ -48,12 +48,8 @@ function Page(site, parent, directory, index, callback) {
 			if (!page._contentFile || err)
 				return callback(err);
 			page.type = path.basename(page._contentFile, site.settings.contentExtension);
-			page.site._addType(page.type, function(err) {
-				if (err)
-					return callback(err);
-				// Parse the content file and place values in page:
-				site.parsers.parseFile(page.getUri(page._contentFile), page, callback);
-			});
+			// Parse the content file and place values in page:
+			site.parsers.parseFile(page.getUri(page._contentFile), page, callback);
 		});
 	});
 }
@@ -262,11 +258,13 @@ Page.prototype = {
 function getTemplate(page, name) {
 	var type = page.type,
 		types = page.site._types;
-	return type && types[type][name]
-		? types[type][name]
-		: types['default'][name] || function(param) {
+	if (type && types[type] && types[type][name]) {
+		return types[type][name];
+	} else {
+		return types['default'][name] || function(param) {
 			return 'Template not found: ' + name;
 		};
+	}
 }
 
 function addFiles(page, done) {
@@ -278,7 +276,11 @@ function addFiles(page, done) {
 
 	var addFile = function(filename, callback) {
 		if (path.extname(filename) == contentExtension) {
-			page._contentFile = filename;
+			// Only set _contentFile if it's empty or
+			// if the current file has a valid template
+			if (!page._contentFile || page.site._types[path.basename(filename, contentExtension)]) {
+				page._contentFile = filename;
+			}
 			return callback();
 		} else {
 			var file = new File(page, index++, filename, function(err) {

--- a/lib/Site.js
+++ b/lib/Site.js
@@ -67,7 +67,7 @@ Site.prototype._addType = function(type, callback) {
 			var templateName = path.basename(file, '.jade');
 			var location = templateLocations[templateName] =
 					path.join(templatesDir, file);
-			fs.readFile(location, 'utf-8', function(err, data) {
+			fs.readFile(location, 'utf8', function(err, data) {
 				if (!err) {
 					typeTemplates[templateName] = jade.compile(data, {
 						filename: location,
@@ -88,7 +88,7 @@ Site.prototype._addType = function(type, callback) {
 	});
 };
 
-// TODO: what happens if this function is called while 
+// TODO: what happens if this function is called while
 // the site is already being built?
 Site.prototype.build = function(callback) {
 	var site = this;
@@ -98,13 +98,25 @@ Site.prototype.build = function(callback) {
 	site._templateLocations = {};
 	site._addType('default', function(err) {
 		if (err)
-			return callback(err);
-		site.root = new Page(site, null, '', null, function(err) {
-			site.modified = Date.now();
-			callback(err);
+			return callback('Error: Default template missing');
+		registerTemplates(site, function (err) {
+			site.root = new Page(site, null, '', null, function(err) {
+				site.modified = Date.now();
+				callback(err);
+			});
 		});
 	});
 };
+function registerTemplates(site, callback) {
+	var uri = getTemplateDirectory(site);
+	fsUtil.listDirectories(uri, function(err, files) {
+		if (err || !files)
+			return callback(err);
+		async.each(files, function (file, cb) {
+			site._addType(file, cb);
+		}, callback);
+	});
+}
 
 function getTemplateDirectory(site, type) {
 	return site.getUri(path.join('templates', type || ''));

--- a/lib/util/fs.js
+++ b/lib/util/fs.js
@@ -22,7 +22,7 @@ function listFiles(dir, callback, _callback) {
 	_callback = _callback || callback;
 	fs.readdir(dir, function(err, files) {
 		if (!files || err)
-			return _callback();
+			return _callback(err);
 		callback(null, sortFiles(files));
 	});
 }


### PR DESCRIPTION
Otherwise it's impossible to differentiate between text files that are the contentFiles and text files that are the description files for images. 

Example:
-01-project
--page.md
--zebra.jpg
--zebra.jpg.md

This would result in zebra.jpg.md being used as the content file. With this change, zebra.jpg.md is not being considered as a content file, since there's no template named "zebra.jpg"
