### PR TITLE
Return empty collection if page has no siblings instead of throwing an error

### DIFF
--- a/lib/Page.js
+++ b/lib/Page.js
@@ -153,7 +153,10 @@ Page.prototype = {
 	 * @return {Page[]}
 	 */
 	getSiblings: function() {
-		return this.parent.children;
+		if (this.parent)
+			return this.parent.children;
+		else
+			return new Collection();
 	},
 
 	/**


### PR DESCRIPTION
Happens when you call getSiblings on the site root, since the site root has no parent
