### PR TITLE
Don't set new root before the site hasn't finished building yet.

### DIFF
--- a/lib/Site.js
+++ b/lib/Site.js
@@ -99,8 +99,9 @@ Site.prototype.build = function(callback) {
 	site._addType('default', function(err) {
 		if (err)
 			return callback(err);
-		site.root = new Page(site, null, '', null, function(err) {
+		var newRoot = new Page(site, null, '', null, function(err) {
 			site.modified = Date.now();
+			site.root = newRoot;
 			callback(err);
 		});
 	});

--- a/lib/woods.js
+++ b/lib/woods.js
@@ -7,7 +7,6 @@ var fsUtil = require('./util/fs.js');
 
 var woods = new EventEmitter();
 woods.express = require('express')();
-woods.sites = [];
 woods.initialize = function (directory, port, watch, callback) {
 	port = port || 3000;
 	woods.express.listen(port);


### PR DESCRIPTION
Otherwise woods serves unfinished pages when stuff just changed. This way we wait for the new site to be build and only then start serving it.
