### PR TITLE
Catch jade errors and display them instead of killing the server.

### DIFF
--- a/lib/Site.js
+++ b/lib/Site.js
@@ -63,16 +63,22 @@ Site.prototype._addType = function(type, callback) {
 
 	var compileTemplate = function(file, doneCompiling) {
 		// Compile jade templates:
-		if ((/jade$/).test(file)) {
+		if (path.extname(file) == '.jade') {
 			var templateName = path.basename(file, '.jade');
 			var location = templateLocations[templateName] =
 					path.join(templatesDir, file);
 			fs.readFile(location, 'utf-8', function(err, data) {
 				if (!err) {
-					typeTemplates[templateName] = jade.compile(data, {
-						filename: location,
-						pretty: true
-					});
+					try {
+						typeTemplates[templateName] = jade.compile(data, {
+							filename: location,
+							pretty: true
+						});
+					} catch (e) {
+						typeTemplates[templateName] = function() {
+							return '<pre>Error compiling template: \n' + e;
+						};
+					}
 				}
 				return doneCompiling(err);
 			});


### PR DESCRIPTION
Also remove an unneeded regex.
Fixes issue #19
