### PR TITLE
Windows Backslash URL Fix

### DIFF
--- a/lib/Page.js
+++ b/lib/Page.js
@@ -1,4 +1,5 @@
 var path = require('path'),
+	url = require('url'),
 	fs = require('fs'),
 	express = require('express'),
 	async = require('async'),
@@ -36,7 +37,7 @@ function Page(site, parent, directory, index, callback) {
 	// Only pages with a number prefixed to their
 	// directory name are marked as being visible.
 	this.visible = /^[0-9]/.test(this.directory);
-	this.url = parent ? path.join(parent.url || '', this.slug + '/') : '/';
+	this.url = parent ? url.resolve(parent.url || '', this.slug + '/') : '/';
 	this.uri = parent ? path.join(parent.uri || '', this.directory) : site.getUri('content');
 	var page = this;
 	addFiles(this, function(err) {


### PR DESCRIPTION
This will fix backslashes in URLs when working in Windows environment.